### PR TITLE
新增 Sentinel namespace 提供 phpredis-sentinel driver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ Desktop.ini
 
 # Artifacts files
 /build
+.tmp/

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 * ext-redis 5.3 ~ 6.2 (Test covered)
 * Redis 6 ~ 7 (Test covered)
 * Predis ^2.0.3
+* `Lab104\Laravel\Redis\Sentinel` namespace 需要 ext-redis >= 6.0（提供 `\RedisSentinel` array constructor）
 
 ## Installation
 
@@ -19,6 +20,8 @@ composer require 104lab/laravel-redis
 ```
 
 ## Usage
+
+### `KeysByScan`
 
 Redis [`KEYS`](https://redis.io/docs/latest/commands/keys/) method is like full-table scan, so maybe use [`SCAN`](https://redis.io/docs/latest/commands/scan/) is good idea.
 
@@ -37,6 +40,117 @@ $keys = (new KeysByScan($connection))('foo:*', 100);
 # Use usleep, default is 10
 $keys = (new KeysByScan($connection))('foo:*', 100, 10);
 ```
+
+### `Sentinel` driver（Redis 高可用）
+
+`Lab104\Laravel\Redis\Sentinel` 提供以 phpredis `\RedisSentinel` 為底的 Laravel Redis driver，
+透過 Sentinel 集群入口（單一 LB endpoint 或多個 sentinel host）解析當前 master，連線失敗時自動重 query Sentinel 取得新 master。
+
+> 完整機制、failover 時序、`slave=0` 邊界、設定範例、故障排除等，請見 [`doc/sentinel.md`](doc/sentinel.md)。
+
+#### 註冊 driver
+
+`SentinelServiceProvider` 透過 composer auto-discover 自動載入；無需手動 require。
+若禁用 auto-discover，請在應用的 `config/app.php` 加上：
+
+```php
+'providers' => [
+    // ...
+    Lab104\Laravel\Redis\Sentinel\SentinelServiceProvider::class,
+],
+```
+
+#### `config/database.php` 設定
+
+```php
+'redis' => [
+    'client' => 'phpredis',
+
+    'default' => [
+        'driver'             => 'phpredis-sentinel',
+        'service'            => env('REDIS_SENTINEL_SERVICE', 'mymaster'),
+        'sentinels'          => array_map(
+            fn (string $hp) => ['host' => explode(':', $hp)[0], 'port' => (int) (explode(':', $hp)[1] ?? 26379)],
+            explode(',', env('REDIS_SENTINELS', 'sentinel.example.com:26379'))
+        ),
+        // sentinel_connect_timeout / sentinel_read_timeout 各自獨立；不設則 fallback 到 sentinel_timeout
+        'sentinel_connect_timeout' => env('REDIS_SENTINEL_CONNECT_TIMEOUT'),
+        'sentinel_read_timeout'    => env('REDIS_SENTINEL_READ_TIMEOUT'),
+        'sentinel_timeout'         => env('REDIS_SENTINEL_TIMEOUT', 0.5),
+        'sentinel_password'        => env('REDIS_SENTINEL_PASSWORD'),
+
+        // 下列欄位為一般 phpredis driver 設定，會在透過 Sentinel 解析到 master 後一併套用
+        'password'           => env('REDIS_PASSWORD'),
+        'database'           => env('REDIS_DB', 0),
+        'read_write_timeout' => env('REDIS_READ_WRITE_TIMEOUT', 0),
+    ],
+],
+```
+
+| 設定鍵 | 必填 | 說明 |
+|---|---|---|
+| `service` | ✅ | Sentinel master group 名稱（例：`mymaster`） |
+| `sentinels` | ✅ | Sentinel 入口清單（單一 LB endpoint 或多個 Sentinel host）；按順序輪試直到成功 |
+| `sentinel_connect_timeout` | | 連 Sentinel 的 connect timeout（秒）；不設則 fallback 到 `sentinel_timeout` |
+| `sentinel_read_timeout` | | 連 Sentinel 的 read timeout（秒）；不設則 fallback 到 `sentinel_timeout` |
+| `sentinel_timeout` | | `sentinel_connect_timeout` / `sentinel_read_timeout` 的共用 fallback（預設 0.5） |
+| `sentinel_password` | | Sentinel 端 ACL 密碼（若啟用認證） |
+| `sentinel_persistent` | | 是否使用 persistent 連線（預設關閉） |
+
+> **建議**：「Sentinel 失聯偵測」與「Sentinel 查詢回應」是兩種特性，failover 演練時可分別調整 `sentinel_connect_timeout`（短）與 `sentinel_read_timeout`（略長）。一般情境用 `sentinel_timeout` 即可。
+
+實際 master / slave 的 `password` / `database` / `prefix` / `read_write_timeout` 等沿用 Laravel `phpredis` driver 既有設定鍵。
+
+#### Connection cache 失效策略
+
+* `Resolver` 將每個 `service` 的 master / slaves 結果快取在 process in-memory；同一 service 後續解析直接 hit cache，不再 query Sentinel。
+* 在連線失敗時（`PhpRedisConnection` 偵測到 `Connection lost` / `went away` / socket 錯誤等），Connector 會在重建 client 前呼叫 `Resolver::invalidate($service)` 清掉該 service 的快取，下次解析會重新 query Sentinel 取得新 master。
+* 呼叫 `Resolver::invalidate()` 不帶參數時清空所有 service 並丟棄底層 `\RedisSentinel` client，用於 Sentinel 入口發生短暫失聯時的 hard reset 情境。
+
+#### `slave list = 0` 邊界處理
+
+當 Sentinel 回傳的 slave list 為 0（或全為 down）時，`Resolver::resolveSlaves()` 會自動把 master 加入 slave 清單，避免讀流量無處可去。
+
+#### 進階：讀流量分流（optional）
+
+本套件預設 `Redis::connection()` 走 master（保持 Laravel single-endpoint 慣例）。
+若 service 端要讀 slave、含 slave=0 fallback master，可呼叫 `Resolver::resolveSlaves()` helper：
+
+```php
+use Lab104\Laravel\Redis\Sentinel\Resolver;
+
+/** @var Resolver $resolver — 由 service 端建構或從 SentinelConnector 取得 */
+$slaves = $resolver->resolveSlaves('mymaster');
+// $slaves 為 [['host' => '...', 'port' => 6379], ...]
+// Slave list 為 0 或全 down 時自動回 [master]
+
+$node = $slaves[array_rand($slaves)];
+$client = new \Redis();
+try {
+    $client->connect($node['host'], $node['port']);
+    $value = $client->get('cache:foo');
+} catch (\RedisException $e) {
+    // Slave 連線失敗 fallback 到 master（透過既有 Laravel connection）
+    $value = Redis::connection('default')->get('cache:foo');
+}
+```
+
+業務模式：
+- 有 Slave：優先用 Slave 讀
+- 沒 Slave：清單只有 master、自動 fallback master
+- Slave 連線失敗：catch 後 fallback master
+- master / slave 連線失敗：Laravel `PhpRedisConnection` 機制觸發 connector closure 重 query Sentinel
+
+#### Failover 預期行為
+
+1. Sentinel 偵測到 master down → 觸發 failover → 推選新 master。
+2. 應用既有 connection 對 master 的下一個指令會收到 `Connection lost` 等錯誤。
+3. Laravel 的 `PhpRedisConnection::command()` 偵測到該錯誤後重建 client → 觸發本套件的 connector closure。
+4. closure 呼叫 `Resolver::invalidate($service)` 後重 query Sentinel，拿到新 master 並重新建立 phpredis 連線。
+5. 後續指令打到新 master，呼叫端透明（命令本身不會自動重試，需由業務層或 framework 端處理重送）。
+
+> 此 driver 僅以單元測試覆蓋邊界邏輯（slave=0、cache 行為、reconnect 時 invalidate 等）。
+> 實機 failover 演練、connection cache 與 long-running worker（如 Octane）的整合驗證請於應用端進行。
 
 ## License
 

--- a/composer.json
+++ b/composer.json
@@ -29,5 +29,15 @@
     "config": {
         "preferred-install": "dist",
         "sort-packages": true
+    },
+    "suggest": {
+        "ext-redis": ">=6.0 (required for Lab104\\Laravel\\Redis\\Sentinel namespace; KeysByScan does not require it)"
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Lab104\\Laravel\\Redis\\Sentinel\\SentinelServiceProvider"
+            ]
+        }
     }
 }

--- a/doc/sentinel.md
+++ b/doc/sentinel.md
@@ -1,0 +1,271 @@
+# `Lab104\Laravel\Redis\Sentinel` 機制說明
+
+本文件說明 `src/Sentinel/` namespace 的設計、運作方式與實機行為，供應用端整合與 Sentinel failover 演練時參考。
+
+## 1. 架構總覽
+
+```mermaid
+flowchart TD
+    App["Application (Laravel)<br/>Redis::connection('default')<br/>driver = phpredis-sentinel"]
+    Connector["SentinelConnector<br/>extends PhpRedisConnector<br/>1) 透過 Resolver 解析當前 master<br/>2) 注入 master host/port<br/>3) 委派建立 \Redis 連線"]
+    Resolver["Resolver<br/>master / slaves cache<br/>slave=0 邊界<br/>invalidate(...)"]
+    Client["PhpRedisSentinelClient<br/>(implements SentinelClientInterface)<br/>包裝 phpredis \RedisSentinel<br/>按 sentinels 清單順序輪試"]
+    Master["\Redis (master)"]
+    Sentinels["Sentinel 入口<br/>(LB endpoint 或多個 sentinel host)<br/>Master + Replica"]
+
+    App --> Connector
+    Connector -->|解析| Resolver
+    Connector -->|連線| Master
+    Resolver -->|"master() / slaves()"| Client
+    Client -->|TCP| Sentinels
+```
+
+## 2. 元件職責
+
+| 類別 / 介面 | 職責 |
+|---|---|
+| `ResolverInterface` | 對外契約：`resolveMaster()` / `resolveSlaves()` / `invalidate()` |
+| `Resolver` | 內含 master / slaves cache、`slave=0` 邊界、lazy 建立 `SentinelClientInterface` |
+| `SentinelClientInterface` | Sentinel 端唯讀查詢介面（`master()` / `slaves()`），讓 Resolver 純單元測試可 mock |
+| `PhpRedisSentinelClient` | `SentinelClientInterface` 的 phpredis 實作；按 sentinels 清單順序輪試直到任一 Sentinel 可連 |
+| `SentinelConnector` | 繼承 `Illuminate\Redis\Connectors\PhpRedisConnector`，先解析 master 再委派 phpredis 建立 `\Redis` |
+| `SentinelServiceProvider` | composer auto-discover 自動註冊 `phpredis-sentinel` driver 到 Laravel `RedisManager` |
+| `SentinelException` | Sentinel 解析 / 連線失敗的領域例外（`RESOLVE_ERROR` / `CONNECTION_ERROR`） |
+
+## 3. master / slave 解析流程
+
+### 3.1 第一次解析
+
+1. `SentinelConnector::connect($config, $options)` 被 Laravel 呼叫
+2. 取出 `service`（master group）與 `sentinels`（Sentinel 入口列表）後建立 `Resolver`
+3. 觸發 `Resolver::resolveMaster($service)` → cache miss
+   - 透過 `SentinelClientInterface::master($service)` 向 Sentinel 查詢
+   - 驗證 `flags` 不含 `s_down` / `o_down` / `disconnected`、`role-reported == master`
+   - 結果寫入 `masterCache[$service]`
+4. 將 `host` / `port` 注入 phpredis 設定，呼叫 `PhpRedisConnector::createClient()` 建立 `\Redis` 連線
+5. 包成 `Illuminate\Redis\Connections\PhpRedisConnection` 回傳，Laravel 後續以此 client 操作 Redis
+
+### 3.2 後續解析（同 process 內）
+
+* `resolveMaster()` / `resolveSlaves()` 直接 hit cache，不再 query Sentinel
+* `Resolver` 內的 `\RedisSentinel` 連線也是 lazy 建立並沿用，不會每次重連 Sentinel
+
+### 3.3 例外行為
+
+| 條件 | 行為 |
+|---|---|
+| Sentinel 回傳 `false` 或 `[]`（master 不存在） | 拋 `SentinelException::masterNotFound($service)` |
+| `flags` 含 `s_down` / `o_down` / `disconnected` | 拋 `SentinelException::masterDown($service, $flags)` |
+| `role-reported != 'master'` | 拋 `SentinelException::masterRoleMismatch(...)` |
+| Sentinel client 建立失敗（所有 sentinels 全失聯） | 拋 `SentinelException`（`CONNECTION_ERROR`），訊息含最後一次 underlying error，`previous` 保留 chain |
+
+flags 比對採 token-based（逗號 split + array_intersect），避免「子字串包含 `down`」的誤判
+（例：未來 Sentinel 加入 `xxx_countdown` / `shutdown_pending` 等含 `down` 子字串但語意非 master down 的 flag）。
+slave 過濾額外含 `master_link_down`（slave 與 master 連線斷、資料可能落後）。
+
+## 4. Connection cache 失效策略
+
+`Resolver` 採用 **process in-memory + 失敗才重 query** 策略。
+
+### 4.1 何時 *不會* 重 query Sentinel
+
+* 第二次以後對同一 `service` 呼叫 `resolveMaster()` / `resolveSlaves()`
+* 應用 worker 一直健康執行、Redis master 沒有 failover
+
+### 4.2 何時 *會* 重 query Sentinel
+
+| 觸發點 | 機制 |
+|---|---|
+| `\Redis` 操作丟連線錯誤（`Connection lost` / `went away` / socket error / `READONLY` …） | Laravel `PhpRedisConnection::command()` 會呼叫 `$this->connector` 重建 client；本套件的 connector closure 在 `attempts > 0` 時先 `Resolver::invalidate($service)` 再解析新 master |
+| 應用層主動呼叫 `Resolver::invalidate($service)` | 清掉指定 service 的 master / slaves cache（其他 service 保留） |
+| 應用層主動呼叫 `Resolver::invalidate()`（不帶參數） | 清掉所有 service cache **並丟棄底層 `\RedisSentinel` 連線**；下次解析重新建立 Sentinel 連線 |
+
+### 4.3 設計理由
+
+* **不設 TTL**：Sentinel 觸發 failover 時應用必然會收到連線錯誤，由錯誤觸發 invalidate 比定時失效更精準、減少 Sentinel 流量。
+* **不在 process 之間共享 cache**：避免新增 Redis / file IO 等共用儲存的依賴；每個 worker 各自重 query 是可接受的。
+* **invalidate 不帶參數會丟棄 `\RedisSentinel` 連線**：用於懷疑 Sentinel 入口本身斷線的情況；此操作較重，僅 hard reset 才用。
+
+## 5. Reconnect 與 failover 行為
+
+### 5.1 失敗 → 重連的時序
+
+```mermaid
+sequenceDiagram
+    participant worker as Laravel worker
+    participant phpconn as PhpRedisConnection
+    participant connector as connector closure<br/>(本套件)
+    participant resolver as Resolver
+    participant sentinel as Sentinel
+    participant master as \Redis (master)
+
+    Note over worker,master: T0 持續使用 cached master 連線執行命令
+    worker->>phpconn: command()
+    phpconn->>master: e.g. SET key value
+    master-->>phpconn: OK
+
+    Note over sentinel,master: T1 Sentinel 偵測 master down → 發起 failover
+    Note over sentinel,master: T2 選出新 master；舊 master 連線進入半關閉
+
+    Note over worker,master: T3 下一個命令觸發失敗
+    worker->>phpconn: command()
+    phpconn->>master: SET key value
+    master-->>phpconn: RedisException("Connection lost")
+
+    Note over phpconn: T4 攔截錯誤<br/>命中 ['went away', 'socket', 'Connection lost', 'READONLY', ...]
+    phpconn->>connector: ()
+
+    Note over connector: T5 attempts > 0
+    connector->>resolver: invalidate($service)
+    connector->>resolver: resolveMaster($service)
+    resolver->>sentinel: master($service)
+    sentinel-->>resolver: 新 master ip:port
+    resolver-->>connector: ['host'=>..., 'port'=>...]
+    connector->>master: 連到新 master
+    connector-->>phpconn: 新 \Redis client
+
+    Note over phpconn: T6 client 已替換
+    phpconn-->>worker: 重 throw RedisException
+
+    Note over worker: T7 業務層 / framework retry 再送指令
+    worker->>phpconn: command()（重試）
+    phpconn->>master: SET key value
+    master-->>phpconn: OK
+```
+
+### 5.2 為什麼不在 Connector 層自動重試命令
+
+Laravel 既有的 `PhpRedisConnection` 設計就是「重建 client，不重試指令」。重試與否屬於業務語義
+（例：寫入是否冪等），由應用層 / queue framework / phpredis 內建 `setOption(OPT_MAX_RETRIES, ...)` 決定，
+本套件刻意不擴張到此範圍以避免雙重重試。
+
+### 5.3 `attempts` 計數的累積行為
+
+`makeMasterResolverClosure()` 內的 `$attempts` 在 closure 整個生命週期單調遞增：
+
+* 首次呼叫 `attempts == 0`，不 invalidate（沿用初始 cache）
+* 第二次起 `attempts > 0`，每次都 invalidate 後重 query Sentinel
+
+在 Octane / Swoole 等 long-running worker 中，**單一 worker process 的 connection 生命週期會跨多 request**，
+意味著「短暫網路抖動 → reconnect 成功 → 後續長時間穩定」的情境下，下一次 reconnect 也會 invalidate
+一次（多走一次 Sentinel 查詢）。語義上保守、副作用是每次 reconnect 多一次 Sentinel 流量，避免出現
+「靠舊 cache 連到舊 master」的死路。如 Sentinel 流量需要嚴格控制再評估改為「成功時 reset attempts」的設計。
+
+### 5.4 應用端整合需驗證的行為
+
+* Sentinel `down-after-milliseconds` × `failover-timeout` × `parallel-syncs` 對應用端的可見延遲
+* `min-replicas-to-write` 與一致性的取捨
+* Octane / Swoole long-running worker 在 master 切換後是否需要 worker 重啟才釋放舊連線
+
+## 6. `slave=0` 邊界處理
+
+### 6.1 規格與動機
+
+當 Sentinel 回傳 slave list 為 0（例：dev/staging 只有 master、或 prod failover 期間所有 slave 都暫時 down）時，
+應用端讀流量會無處可去。`Resolver::fetchSlaves()` 在此情境下把 master 加入清單作為 fallback：
+
+```php
+if (count($list) === 0) {
+    $list[] = $this->resolveMaster($service);
+}
+```
+
+### 6.2 涵蓋情境
+
+| Sentinel 回應 | `Resolver::resolveSlaves()` 結果 |
+|---|---|
+| `[]`（沒有 slave 已註冊） | `[ master ]` |
+| 全部 slave 含 `flags=*down*` | `[ master ]`（過濾後 list 為空，再 fallback） |
+| `false`（部分 phpredis 版本可能回 false） | `[ master ]` |
+| 1 個 healthy slave | `[ slave ]` |
+| 多個 slave（含部分 down） | 過濾掉 down 的後回傳 healthy slaves |
+
+### 6.3 單元測試覆蓋
+
+`tests/Unit/Sentinel/ResolverTest.php`：
+
+* `itFallsBackToMasterWhenSlaveListIsEmpty`
+* `itFallsBackToMasterWhenAllSlavesAreDown`
+* `itFallsBackToMasterWhenSentinelReturnsFalseForSlaves`
+* `itFiltersOutDownSlaves`
+
+## 7. 測試覆蓋清單
+
+| 測試檔 | 測試項數 | 覆蓋面向 |
+|---|---|---|
+| `tests/Unit/Sentinel/ResolverTest.php` | 21 | master / slaves 解析、cache、`slave=0` 邊界、down 過濾（token-based）、`disconnected` / `master_link_down`、role-reported 驗證、invalidate 行為、lazy client、builder throw 後 retry |
+| `tests/Unit/Sentinel/SentinelConnectorTest.php` | 7 | reconnect 時 invalidate 觸發點、attempts 計數獨立性、必填 config 驗證、sentinels 結構錯誤訊息含 index |
+| `tests/Unit/Sentinel/PhpRedisSentinelClientTest.php` | 6 | 建構參數驗證、sentinel 順序輪試、全失敗時 `previous` chain（最後 underlying error 不丟失） |
+
+> 整合測試（連實機 Sentinel + 手動觸發 failover 驗證 reconnect）由應用端負責；
+> 本套件不維護整合測試以避免綁定特定 Sentinel 部署。
+
+## 8. 設定 / `.env` 對應
+
+### 8.1 `config/database.php`
+
+```php
+'redis' => [
+    'client' => 'phpredis',
+
+    'default' => [
+        'driver'             => 'phpredis-sentinel',
+        'service'            => env('REDIS_SENTINEL_SERVICE'),
+        'sentinels'          => collect(explode(',', env('REDIS_SENTINELS', '')))
+            ->filter()
+            ->map(fn (string $hp) => [
+                'host' => explode(':', $hp)[0],
+                'port' => (int) (explode(':', $hp)[1] ?? 26379),
+            ])
+            ->values()
+            ->all(),
+        // sentinel_connect_timeout / sentinel_read_timeout 各自獨立；不設則 fallback 到 sentinel_timeout
+        'sentinel_connect_timeout' => env('REDIS_SENTINEL_CONNECT_TIMEOUT'),
+        'sentinel_read_timeout'    => env('REDIS_SENTINEL_READ_TIMEOUT'),
+        'sentinel_timeout'   => (float) env('REDIS_SENTINEL_TIMEOUT', 0.5),
+        'sentinel_password'  => env('REDIS_SENTINEL_PASSWORD'),
+
+        // 一般 phpredis 設定（解析到 master 後一併套用）
+        'password'           => env('REDIS_PASSWORD'),
+        'database'           => (int) env('REDIS_DB', 0),
+        'read_write_timeout' => (float) env('REDIS_READ_WRITE_TIMEOUT', 0),
+    ],
+],
+```
+
+### 8.2 必要 `.env` 變數
+
+| 變數 | 說明 |
+|---|---|
+| `REDIS_SENTINELS` | Sentinel 入口清單（單一 LB 或多個 sentinel host），逗號分隔 `host:port`（例：`sentinel.example.com:26379` 或 `sentinel-a:26379,sentinel-b:26379,sentinel-c:26379`） |
+| `REDIS_SENTINEL_SERVICE` | Sentinel master group 名稱（例：`mymaster`） |
+| `REDIS_SENTINEL_CONNECT_TIMEOUT` | （選）連 Sentinel 的 connect timeout；不設則 fallback 到 `REDIS_SENTINEL_TIMEOUT` |
+| `REDIS_SENTINEL_READ_TIMEOUT` | （選）連 Sentinel 的 read timeout；不設則 fallback 到 `REDIS_SENTINEL_TIMEOUT` |
+| `REDIS_SENTINEL_TIMEOUT` | （選）connect / read timeout 的共用 fallback（預設 0.5） |
+| `REDIS_SENTINEL_PASSWORD` | （選）Sentinel 端 ACL 密碼 |
+| `REDIS_PASSWORD` | master / replica 的密碼（與既有設定相同） |
+
+> 「Sentinel 失聯偵測」與「Sentinel 查詢回應」是兩種特性，可分別調整 `REDIS_SENTINEL_CONNECT_TIMEOUT`（短，例 0.3）與 `REDIS_SENTINEL_READ_TIMEOUT`（略長，例 1.0）。一般情境用 `REDIS_SENTINEL_TIMEOUT` 即可。
+
+### 8.3 Rollback fallback
+
+切換期間建議在 `config/database.php` 保留原 `REDIS_HOST` 對應的 connection 設定，並透過
+deployment 的環境變數切換 driver；不要刪除舊變數，rollback 時以環境變數變更即可恢復。
+
+## 9. 故障排除
+
+| 症狀 | 可能原因 | 排查 |
+|---|---|---|
+| 啟動時拋 `SentinelException`（`CONNECTION_ERROR`） | 所有 sentinels 都連不到 / 認證錯誤 | 檢查 `REDIS_SENTINELS` 是否可達；確認 `REDIS_SENTINEL_PASSWORD` |
+| 啟動時拋 `TypeError` / `Class RedisSentinel not found` | ext-redis < 6.0 或未啟用 | `php --re redis | grep RedisSentinel` 或 `php -r "echo phpversion('redis');"` 確認版本 ≥ 6.0；composer suggest 段落已宣告此需求 |
+| 啟動時拋 `master group [...] not found` | `REDIS_SENTINEL_SERVICE` 與 Sentinel 端設定不符 | 確認 master group 名稱 |
+| 啟動時拋 `master group [...] reported down` | Sentinel 端短暫看到 master down | 重試啟動；若持續 → 聯絡資料庫端維運 |
+| 寫入時偶發 `Connection lost` 但下一次成功 | 正常 failover 流程 | 觀察 retry 機制是否有把命令重送 |
+| `Octane` worker 在 failover 後仍打到舊 master | worker 仍持有舊 \Redis client | 需重啟 worker，或於 `octane.php` 配置 `DisconnectFromDatabases` listener |
+
+## 10. 套件版本相容
+
+* PHP `^8.1`
+* Laravel `^10` / `^11` / `^12`
+* `ext-redis >= 6.0`（`\RedisSentinel` array constructor）
+* 既有 `Lab104\Laravel\Redis\KeysByScan` 用法**不受影響**，可與 Sentinel namespace 並存使用

--- a/src/Sentinel/PhpRedisSentinelClient.php
+++ b/src/Sentinel/PhpRedisSentinelClient.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lab104\Laravel\Redis\Sentinel;
+
+use InvalidArgumentException;
+use RedisSentinel;
+use Throwable;
+
+/**
+ * 以 phpredis 的 \RedisSentinel 為底，按設定順序輪試 sentinel host。
+ * 抽出此薄封裝是為了讓 Resolver 介面保持精簡且可純單元測試（不需依賴 ext-redis 與實機 Sentinel）。
+ */
+class PhpRedisSentinelClient implements SentinelClientInterface
+{
+    /**
+     * @var array<int, array{host: string, port?: int|string}>
+     */
+    private array $sentinels;
+
+    /**
+     * @var array<string, mixed>
+     */
+    private array $options;
+
+    private ?RedisSentinel $client = null;
+
+    /**
+     * @param array<int, array{host: string, port?: int|string}> $sentinels
+     * @param array{
+     *     connectTimeout?: float,
+     *     readTimeout?: float,
+     *     auth?: string|array<int, string>|null,
+     *     persistent?: bool,
+     *     retryInterval?: int,
+     * } $options
+     */
+    public function __construct(array $sentinels, array $options = [])
+    {
+        self::assertSentinelsShape($sentinels);
+
+        $this->sentinels = array_values($sentinels);
+        $this->options = $options;
+    }
+
+    /**
+     * 驗證 sentinel 陣列結構。Connector 與 Client 兩個入口共用，避免邏輯重複且訊息一致。
+     *
+     * @param array<int, array{host?: mixed, port?: mixed}>|array<mixed> $sentinels
+     */
+    public static function assertSentinelsShape(array $sentinels): void
+    {
+        if ($sentinels === []) {
+            throw new InvalidArgumentException('Sentinel host list must not be empty');
+        }
+
+        foreach ($sentinels as $idx => $entry) {
+            if (!is_array($entry) || !isset($entry['host']) || !is_string($entry['host']) || $entry['host'] === '') {
+                throw new InvalidArgumentException(
+                    "sentinels[{$idx}] must be an array with a non-empty 'host' key"
+                );
+            }
+        }
+    }
+
+    /**
+     * @return array{ip: string, port: int|string, flags: string, role-reported: string}|false
+     */
+    public function master(string $service): array|false
+    {
+        return $this->client()->master($service);
+    }
+
+    /**
+     * @return array<int, array{ip: string, port: int|string, flags: string}>|false
+     */
+    public function slaves(string $service): array|false
+    {
+        return $this->client()->slaves($service);
+    }
+
+    private function client(): RedisSentinel
+    {
+        if ($this->client !== null) {
+            return $this->client;
+        }
+
+        $lastError = null;
+        foreach ($this->sentinels as $sentinel) {
+            try {
+                return $this->client = $this->createClient($sentinel);
+            } catch (Throwable $e) {
+                $lastError = $e;
+            }
+        }
+
+        throw new SentinelException(
+            'Unable to connect to any Sentinel host: ' . ($lastError?->getMessage() ?? 'unknown error'),
+            SentinelException::CONNECTION_ERROR,
+            $lastError
+        );
+    }
+
+    /**
+     * 抽為 protected 以便測試覆寫 — 真實環境會建立 \RedisSentinel；測試可注入 fake/throw。
+     *
+     * @param array{host: string, port?: int|string} $sentinel
+     */
+    protected function createClient(array $sentinel): RedisSentinel
+    {
+        $config = ['host' => $sentinel['host'], 'port' => (int) ($sentinel['port'] ?? 26379)];
+
+        foreach (['connectTimeout', 'readTimeout', 'persistent', 'retryInterval', 'auth'] as $key) {
+            if (array_key_exists($key, $this->options) && $this->options[$key] !== null) {
+                $config[$key] = $this->options[$key];
+            }
+        }
+
+        return new RedisSentinel($config);
+    }
+}

--- a/src/Sentinel/Resolver.php
+++ b/src/Sentinel/Resolver.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lab104\Laravel\Redis\Sentinel;
+
+use Closure;
+
+class Resolver implements ResolverInterface
+{
+    /**
+     * Sentinel master flag 代表「該節點不可用」的 token。
+     *  - s_down：本 Sentinel 認為 down
+     *  - o_down：多數 Sentinel 同意 down（已成真實 down）
+     *  - disconnected：Sentinel 與該節點失聯
+     * 採 token-based 比對避免「子字串包含 down」的誤判（例：未來新增 *_countdown / shutdown_pending）。
+     */
+    private const MASTER_DOWN_FLAGS = ['s_down', 'o_down', 'disconnected'];
+
+    /**
+     * Sentinel slave 多了 `master_link_down`：表示此 slave 與 master 連線斷，資料可能落後，
+     * 不該被當作可讀節點。
+     */
+    private const SLAVE_DOWN_FLAGS = ['s_down', 'o_down', 'disconnected', 'master_link_down'];
+
+    /**
+     * @var Closure(): SentinelClientInterface
+     */
+    private Closure $clientBuilder;
+
+    private ?SentinelClientInterface $client = null;
+
+    /**
+     * @var array<string, array{host: string, port: int}>
+     */
+    private array $masterCache = [];
+
+    /**
+     * @var array<string, array<int, array{host: string, port: int}>>
+     */
+    private array $slavesCache = [];
+
+    /**
+     * @param Closure(): SentinelClientInterface $clientBuilder
+     */
+    public function __construct(Closure $clientBuilder)
+    {
+        $this->clientBuilder = $clientBuilder;
+    }
+
+    public function resolveMaster(string $service): array
+    {
+        if (isset($this->masterCache[$service])) {
+            return $this->masterCache[$service];
+        }
+
+        return $this->masterCache[$service] = $this->fetchMaster($service);
+    }
+
+    public function resolveSlaves(string $service): array
+    {
+        if (isset($this->slavesCache[$service])) {
+            return $this->slavesCache[$service];
+        }
+
+        return $this->slavesCache[$service] = $this->fetchSlaves($service);
+    }
+
+    public function invalidate(?string $service = null): void
+    {
+        if ($service === null) {
+            $this->masterCache = [];
+            $this->slavesCache = [];
+            $this->client = null;
+
+            return;
+        }
+
+        unset($this->masterCache[$service], $this->slavesCache[$service]);
+    }
+
+    /**
+     * @return array{host: string, port: int}
+     */
+    private function fetchMaster(string $service): array
+    {
+        $info = $this->client()->master($service);
+
+        if (!is_array($info) || $info === []) {
+            throw SentinelException::masterNotFound($service);
+        }
+
+        $flags = (string) ($info['flags'] ?? '');
+        if (self::flagsContainAnyOf($flags, self::MASTER_DOWN_FLAGS)) {
+            throw SentinelException::masterDown($service, $flags);
+        }
+
+        $role = (string) ($info['role-reported'] ?? '');
+        if ($role !== 'master') {
+            throw SentinelException::masterRoleMismatch($service, $role);
+        }
+
+        return [
+            'host' => (string) $info['ip'],
+            'port' => (int) $info['port'],
+        ];
+    }
+
+    /**
+     * @return array<int, array{host: string, port: int}>
+     */
+    private function fetchSlaves(string $service): array
+    {
+        $slaves = $this->client()->slaves($service);
+        if (!is_array($slaves)) {
+            $slaves = [];
+        }
+
+        $list = [];
+        foreach ($slaves as $slave) {
+            if (!is_array($slave)) {
+                continue;
+            }
+            $flags = (string) ($slave['flags'] ?? '');
+            if (self::flagsContainAnyOf($flags, self::SLAVE_DOWN_FLAGS)) {
+                continue;
+            }
+            $list[] = [
+                'host' => (string) $slave['ip'],
+                'port' => (int) $slave['port'],
+            ];
+        }
+
+        // 沒有可用 slave 時把 master 加入清單，避免讀流量無處可去（dev/staging 可能只有 master，
+        // 或 prod failover 期間所有 slave 都暫時 down 的邊界情境）。
+        // 副作用：透過 resolveMaster() 而非 fetchMaster()，會把 master 寫進 masterCache，
+        // 確保 fallback 用的 master ip 與下一次 resolveMaster() 視角一致。
+        if (count($list) === 0) {
+            $list[] = $this->resolveMaster($service);
+        }
+
+        return $list;
+    }
+
+    /**
+     * Sentinel 的 flags 欄位是逗號分隔 token。本 helper 將其拆開後與 $downFlags 做集合相交。
+     *
+     * @param array<int, string> $downFlags
+     */
+    private static function flagsContainAnyOf(string $flags, array $downFlags): bool
+    {
+        $tokens = array_filter(array_map('trim', explode(',', $flags)));
+        return array_intersect($downFlags, $tokens) !== [];
+    }
+
+    private function client(): SentinelClientInterface
+    {
+        if ($this->client === null) {
+            $this->client = ($this->clientBuilder)();
+        }
+
+        return $this->client;
+    }
+}

--- a/src/Sentinel/ResolverInterface.php
+++ b/src/Sentinel/ResolverInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lab104\Laravel\Redis\Sentinel;
+
+interface ResolverInterface
+{
+    /**
+     * @return array{host: string, port: int}
+     */
+    public function resolveMaster(string $service): array;
+
+    /**
+     * @return array<int, array{host: string, port: int}>
+     */
+    public function resolveSlaves(string $service): array;
+
+    /**
+     * 失效 master / slaves 快取。
+     *
+     * 不帶參數會清掉全部 service 並丟棄底層 Sentinel client（適用 Sentinel 入口失聯的 hard reset）；
+     * 帶 service 名只清該 service 的快取，其他 service 的解析結果保留。
+     */
+    public function invalidate(?string $service = null): void;
+}

--- a/src/Sentinel/SentinelClientInterface.php
+++ b/src/Sentinel/SentinelClientInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lab104\Laravel\Redis\Sentinel;
+
+interface SentinelClientInterface
+{
+    /**
+     * @return array{ip: string, port: int|string, flags: string, role-reported: string}|false
+     */
+    public function master(string $service): array|false;
+
+    /**
+     * @return array<int, array{ip: string, port: int|string, flags: string}>|false
+     */
+    public function slaves(string $service): array|false;
+}

--- a/src/Sentinel/SentinelConnector.php
+++ b/src/Sentinel/SentinelConnector.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lab104\Laravel\Redis\Sentinel;
+
+use Closure;
+use Illuminate\Redis\Connections\PhpRedisConnection;
+use Illuminate\Redis\Connectors\PhpRedisConnector;
+use Illuminate\Support\Arr;
+use InvalidArgumentException;
+
+/**
+ * 自訂 Laravel Redis Connector：建立連線前先透過 Sentinel 解析當前 master，再委派給 phpredis。
+ *
+ * Laravel `PhpRedisConnection::command()` 在連線中斷錯誤（Connection lost / went away …）時會呼叫
+ * connector closure 重建 client；本 Connector 在該 closure 中觸發 resolver invalidate，使 reconnect
+ * 自動重 query Sentinel 取得新 master，達成對呼叫端透明的 failover。
+ */
+class SentinelConnector extends PhpRedisConnector
+{
+    /**
+     * @var (Closure(array<int, array{host: string, port?: int|string}>, array<string, mixed>): ResolverInterface)|null
+     */
+    private ?Closure $resolverFactory;
+
+    /**
+     * @param (Closure(
+     *     array<int, array{host: string, port?: int|string}>,
+     *     array<string, mixed>
+     * ): ResolverInterface)|null $resolverFactory  建立 Resolver 的 factory；預設使用 phpredis \RedisSentinel
+     *     為底的實作。測試時可注入 mock resolver。
+     */
+    public function __construct(?Closure $resolverFactory = null)
+    {
+        $this->resolverFactory = $resolverFactory;
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     * @param array<string, mixed> $options
+     */
+    public function connect(array $config, array $options): PhpRedisConnection
+    {
+        $service = $config['service'] ?? null;
+        if (!is_string($service) || $service === '') {
+            throw new InvalidArgumentException("Sentinel connection config requires a non-empty 'service' key");
+        }
+
+        $sentinels = $config['sentinels'] ?? null;
+        if (!is_array($sentinels)) {
+            throw new InvalidArgumentException("Sentinel connection config requires a non-empty 'sentinels' array");
+        }
+        // 與 PhpRedisSentinelClient 共用同一份結構驗證，確保訊息一致；提早到 Connector 邊界 fail fast。
+        PhpRedisSentinelClient::assertSentinelsShape($sentinels);
+
+        $resolver = $this->buildResolver($sentinels, $config);
+
+        $upstreamConfig = $this->stripSentinelKeys($config);
+
+        $formattedOptions = Arr::pull($upstreamConfig, 'options', []);
+        if (isset($upstreamConfig['prefix'])) {
+            $formattedOptions['prefix'] = $upstreamConfig['prefix'];
+        }
+
+        $masterResolver = self::makeMasterResolverClosure($resolver, $service);
+
+        // 將 master host/port 注入 phpredis config 後委派 PhpRedisConnector::createClient()，
+        // 這樣 Laravel 既有的 phpredis 設定（auth、database、prefix、timeout …）都會自動生效。
+        $clientConnector = function () use ($masterResolver, $upstreamConfig, $options, $formattedOptions) {
+            $master = $masterResolver();
+
+            // Sentinel 解析的 master host/port 是動態決定，必須具最高優先；
+            // 放在 array_merge 最末位以覆蓋 $options / $formattedOptions 中可能誤設的 host/port。
+            return $this->createClient(array_merge(
+                $upstreamConfig,
+                $options,
+                $formattedOptions,
+                ['host' => $master['host'], 'port' => $master['port']]
+            ));
+        };
+
+        return new PhpRedisConnection($clientConnector(), $clientConnector, $upstreamConfig);
+    }
+
+    /**
+     * 產生「解析 master + reconnect 時失效快取」的 closure。
+     *
+     * 第一次呼叫直接走快取解析；第二次起呼叫會先 invalidate，迫使 Resolver 重 query Sentinel。
+     * 抽成 static helper 是為了讓 failover 行為（不含真連 Redis）可獨立做單元測試。
+     *
+     * @return Closure(): array{host: string, port: int}
+     */
+    public static function makeMasterResolverClosure(ResolverInterface $resolver, string $service): Closure
+    {
+        $attempts = 0;
+
+        return function () use ($resolver, $service, &$attempts): array {
+            if ($attempts > 0) {
+                // Reconnect 路徑：丟掉快取的 topology，讓下一次解析重 query Sentinel 取得新 master。
+                $resolver->invalidate($service);
+            }
+            $attempts++;
+
+            return $resolver->resolveMaster($service);
+        };
+    }
+
+    /**
+     * @param array<int, array{host: string, port?: int|string}> $sentinels
+     * @param array<string, mixed> $config
+     */
+    private function buildResolver(array $sentinels, array $config): ResolverInterface
+    {
+        $factory = $this->resolverFactory ?? self::defaultResolverFactory();
+
+        return $factory($sentinels, $config);
+    }
+
+    /**
+     * @return Closure(array<int, array{host: string, port?: int|string}>, array<string, mixed>): ResolverInterface
+     */
+    private static function defaultResolverFactory(): Closure
+    {
+        return function (array $sentinels, array $config): ResolverInterface {
+            // sentinel_connect_timeout / sentinel_read_timeout 各自獨立；sentinel_timeout 為 fallback alias。
+            // 區分 connect 與 read 是因為「Sentinel 失聯偵測快不快」與「Sentinel 查詢回應慢不慢」屬不同特性。
+            $sharedTimeout = isset($config['sentinel_timeout']) ? (float) $config['sentinel_timeout'] : null;
+            $connectTimeout = isset($config['sentinel_connect_timeout'])
+                ? (float) $config['sentinel_connect_timeout']
+                : $sharedTimeout;
+            $readTimeout = isset($config['sentinel_read_timeout'])
+                ? (float) $config['sentinel_read_timeout']
+                : $sharedTimeout;
+
+            $clientOptions = array_filter([
+                'connectTimeout' => $connectTimeout,
+                'readTimeout' => $readTimeout,
+                'auth' => $config['sentinel_password'] ?? null,
+                'persistent' => $config['sentinel_persistent'] ?? null,
+            ], static fn ($value) => $value !== null);
+
+            return new Resolver(static fn (): SentinelClientInterface => new PhpRedisSentinelClient(
+                $sentinels,
+                $clientOptions
+            ));
+        };
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     * @return array<string, mixed>
+     */
+    private function stripSentinelKeys(array $config): array
+    {
+        unset(
+            $config['sentinels'],
+            $config['service'],
+            $config['sentinel_timeout'],
+            $config['sentinel_connect_timeout'],
+            $config['sentinel_read_timeout'],
+            $config['sentinel_password'],
+            $config['sentinel_persistent']
+        );
+
+        return $config;
+    }
+}

--- a/src/Sentinel/SentinelException.php
+++ b/src/Sentinel/SentinelException.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lab104\Laravel\Redis\Sentinel;
+
+use RuntimeException;
+
+class SentinelException extends RuntimeException
+{
+    public const RESOLVE_ERROR = 100;
+    public const CONNECTION_ERROR = 200;
+
+    public static function masterNotFound(string $service): self
+    {
+        return new self("Sentinel master group [{$service}] not found", self::RESOLVE_ERROR);
+    }
+
+    public static function masterDown(string $service, string $flags): self
+    {
+        return new self(
+            "Sentinel master group [{$service}] reported down (flags: {$flags})",
+            self::RESOLVE_ERROR
+        );
+    }
+
+    public static function masterRoleMismatch(string $service, string $role): self
+    {
+        return new self(
+            "Sentinel master group [{$service}] role must be 'master' but got '{$role}'",
+            self::RESOLVE_ERROR
+        );
+    }
+}

--- a/src/Sentinel/SentinelServiceProvider.php
+++ b/src/Sentinel/SentinelServiceProvider.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lab104\Laravel\Redis\Sentinel;
+
+use Illuminate\Contracts\Container\Container;
+use Illuminate\Redis\RedisManager;
+use Illuminate\Support\ServiceProvider;
+
+/**
+ * 在 Laravel Redis Manager 註冊 'phpredis-sentinel' driver，讓 service 端只要在
+ * config/database.php 寫 `'driver' => 'phpredis-sentinel'` 即可啟用 Sentinel 模式。
+ *
+ * 透過 composer.json 的 "extra.laravel.providers" 自動載入，service 端無需手動註冊 Provider。
+ */
+class SentinelServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        $this->app->afterResolving('redis', static function ($redis, Container $app): void {
+            if ($redis instanceof RedisManager) {
+                $redis->extend('phpredis-sentinel', static fn () => new SentinelConnector());
+            }
+        });
+    }
+}

--- a/tests/Unit/Sentinel/PhpRedisSentinelClientTest.php
+++ b/tests/Unit/Sentinel/PhpRedisSentinelClientTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Sentinel;
+
+use InvalidArgumentException;
+use Lab104\Laravel\Redis\Sentinel\PhpRedisSentinelClient;
+use Lab104\Laravel\Redis\Sentinel\SentinelException;
+use PHPUnit\Framework\Attributes\Test;
+use RedisSentinel;
+use RuntimeException;
+use Tests\TestCase;
+
+class PhpRedisSentinelClientTest extends TestCase
+{
+    #[Test]
+    public function itRejectsEmptySentinelList(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Sentinel host list must not be empty');
+
+        new PhpRedisSentinelClient([]);
+    }
+
+    #[Test]
+    public function itRejectsSentinelEntryWithoutHost(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("sentinels[0]");
+
+        new PhpRedisSentinelClient([['port' => 26379]]);
+    }
+
+    #[Test]
+    public function itRejectsSentinelEntryWithEmptyHost(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("sentinels[0]");
+
+        new PhpRedisSentinelClient([['host' => '', 'port' => 26379]]);
+    }
+
+    #[Test]
+    public function itReportsIndexInValidationErrorMessage(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("sentinels[1]");
+
+        new PhpRedisSentinelClient([
+            ['host' => 'sentinel-a', 'port' => 26379],
+            ['port' => 26379],  // 缺 host
+        ]);
+    }
+
+    #[Test]
+    public function itTriesAllSentinelsAndChainsLastErrorWhenAllFail(): void
+    {
+        // 所有 sentinels 全失聯時要丟出明確錯誤、不 hang；previous 保留最後一次 underlying error。
+        $client = new class ([
+            ['host' => 'sentinel-a', 'port' => 26379],
+            ['host' => 'sentinel-b', 'port' => 26379],
+            ['host' => 'sentinel-c', 'port' => 26379],
+        ]) extends PhpRedisSentinelClient {
+            /** @var array<int, string> */
+            public array $attempted = [];
+
+            protected function createClient(array $sentinel): RedisSentinel
+            {
+                $this->attempted[] = $sentinel['host'];
+                throw new RuntimeException("cannot connect to {$sentinel['host']}");
+            }
+        };
+
+        try {
+            $client->master('mymaster');
+            $this->fail('expected SentinelException');
+        } catch (SentinelException $e) {
+            $this->assertSame(SentinelException::CONNECTION_ERROR, $e->getCode());
+            $this->assertStringContainsString('cannot connect to sentinel-c', $e->getMessage());
+            $this->assertNotNull($e->getPrevious());
+            $this->assertSame(
+                ['sentinel-a', 'sentinel-b', 'sentinel-c'],
+                $client->attempted,
+                'should iterate sentinels in order until all fail'
+            );
+        }
+    }
+
+    #[Test]
+    public function itReturnsFirstReachableSentinelClient(): void
+    {
+        $stubClient = $this->createMock(RedisSentinel::class);
+        $stubClient->method('master')->willReturn([
+            'ip' => '10.0.0.1', 'port' => 6379, 'flags' => 'master', 'role-reported' => 'master',
+        ]);
+
+        $client = new class (
+            [
+                ['host' => 'sentinel-a', 'port' => 26379],
+                ['host' => 'sentinel-b', 'port' => 26379],
+            ],
+            [],
+            $stubClient
+        ) extends PhpRedisSentinelClient {
+            /** @var array<int, string> */
+            public array $attempted = [];
+            private RedisSentinel $stub;
+
+            public function __construct(array $sentinels, array $options, RedisSentinel $stub)
+            {
+                parent::__construct($sentinels, $options);
+                $this->stub = $stub;
+            }
+
+            protected function createClient(array $sentinel): RedisSentinel
+            {
+                $this->attempted[] = $sentinel['host'];
+                if ($sentinel['host'] === 'sentinel-a') {
+                    throw new RuntimeException('first sentinel down');
+                }
+                return $this->stub;
+            }
+        };
+
+        $info = $client->master('mymaster');
+
+        $this->assertIsArray($info);
+        $this->assertSame('10.0.0.1', $info['ip']);
+        $this->assertSame(['sentinel-a', 'sentinel-b'], $client->attempted);
+    }
+}

--- a/tests/Unit/Sentinel/ResolverTest.php
+++ b/tests/Unit/Sentinel/ResolverTest.php
@@ -1,0 +1,474 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Sentinel;
+
+use Lab104\Laravel\Redis\Sentinel\Resolver;
+use Lab104\Laravel\Redis\Sentinel\SentinelClientInterface;
+use Lab104\Laravel\Redis\Sentinel\SentinelException;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class ResolverTest extends TestCase
+{
+    /**
+     * @return SentinelClientInterface&\PHPUnit\Framework\MockObject\MockObject
+     */
+    private function makeClient(): SentinelClientInterface
+    {
+        return $this->createMock(SentinelClientInterface::class);
+    }
+
+    /**
+     * 建立一個 Resolver；其 lazy 建立的 client 固定為傳入的 mock。
+     * `$builderCalls` 用來檢查 lazy 建立行為（第幾次呼叫才實際建立 client）。
+     */
+    private function makeResolver(SentinelClientInterface $client, ?int &$builderCalls = null): Resolver
+    {
+        $builderCalls = 0;
+        return new Resolver(function () use ($client, &$builderCalls): SentinelClientInterface {
+            $builderCalls++;
+            return $client;
+        });
+    }
+
+    #[Test]
+    public function itResolvesMasterWithCorrectHostAndPort(): void
+    {
+        $client = $this->makeClient();
+        $client->expects($this->once())
+            ->method('master')
+            ->with('mymaster')
+            ->willReturn([
+                'ip' => '10.0.0.1',
+                'port' => '6379',
+                'flags' => 'master',
+                'role-reported' => 'master',
+            ]);
+
+        $resolver = $this->makeResolver($client);
+
+        $this->assertSame(
+            ['host' => '10.0.0.1', 'port' => 6379],
+            $resolver->resolveMaster('mymaster')
+        );
+    }
+
+    #[Test]
+    public function itCachesMasterResolutionOnSubsequentCalls(): void
+    {
+        $client = $this->makeClient();
+        $client->expects($this->once())
+            ->method('master')
+            ->willReturn([
+                'ip' => '10.0.0.1',
+                'port' => 6379,
+                'flags' => 'master',
+                'role-reported' => 'master',
+            ]);
+
+        $resolver = $this->makeResolver($client);
+        $resolver->resolveMaster('mymaster');
+        $resolver->resolveMaster('mymaster');
+    }
+
+    #[Test]
+    public function itResolvesSlavesWithCorrectHostAndPort(): void
+    {
+        $client = $this->makeClient();
+        $client->method('slaves')
+            ->with('mymaster')
+            ->willReturn([
+                ['ip' => '10.0.0.2', 'port' => '6379', 'flags' => 'slave'],
+                ['ip' => '10.0.0.3', 'port' => 6380, 'flags' => 'slave'],
+            ]);
+
+        $resolver = $this->makeResolver($client);
+
+        $this->assertSame(
+            [
+                ['host' => '10.0.0.2', 'port' => 6379],
+                ['host' => '10.0.0.3', 'port' => 6380],
+            ],
+            $resolver->resolveSlaves('mymaster')
+        );
+    }
+
+    #[Test]
+    public function itFiltersOutDownSlaves(): void
+    {
+        $client = $this->makeClient();
+        $client->method('slaves')->willReturn([
+            ['ip' => '10.0.0.2', 'port' => 6379, 'flags' => 'slave'],
+            ['ip' => '10.0.0.3', 'port' => 6379, 'flags' => 's_down,slave'],
+            ['ip' => '10.0.0.4', 'port' => 6379, 'flags' => 'slave,o_down'],
+        ]);
+
+        $resolver = $this->makeResolver($client);
+
+        $this->assertSame(
+            [['host' => '10.0.0.2', 'port' => 6379]],
+            $resolver->resolveSlaves('mymaster')
+        );
+    }
+
+    #[Test]
+    public function itFallsBackToMasterWhenSlaveListIsEmpty(): void
+    {
+        $client = $this->makeClient();
+        $client->method('master')->willReturn([
+            'ip' => '10.0.0.1',
+            'port' => 6379,
+            'flags' => 'master',
+            'role-reported' => 'master',
+        ]);
+        $client->method('slaves')->willReturn([]);
+
+        $resolver = $this->makeResolver($client);
+
+        $this->assertSame(
+            [['host' => '10.0.0.1', 'port' => 6379]],
+            $resolver->resolveSlaves('mymaster')
+        );
+    }
+
+    #[Test]
+    public function itFallsBackToMasterWhenAllSlavesAreDown(): void
+    {
+        $client = $this->makeClient();
+        $client->method('master')->willReturn([
+            'ip' => '10.0.0.1',
+            'port' => 6379,
+            'flags' => 'master',
+            'role-reported' => 'master',
+        ]);
+        $client->method('slaves')->willReturn([
+            ['ip' => '10.0.0.2', 'port' => 6379, 'flags' => 's_down'],
+            ['ip' => '10.0.0.3', 'port' => 6379, 'flags' => 'o_down'],
+        ]);
+
+        $resolver = $this->makeResolver($client);
+
+        $this->assertSame(
+            [['host' => '10.0.0.1', 'port' => 6379]],
+            $resolver->resolveSlaves('mymaster')
+        );
+    }
+
+    #[Test]
+    public function itFallsBackToMasterWhenSentinelReturnsFalseForSlaves(): void
+    {
+        $client = $this->makeClient();
+        $client->method('master')->willReturn([
+            'ip' => '10.0.0.1',
+            'port' => 6379,
+            'flags' => 'master',
+            'role-reported' => 'master',
+        ]);
+        $client->method('slaves')->willReturn(false);
+
+        $resolver = $this->makeResolver($client);
+
+        $this->assertSame(
+            [['host' => '10.0.0.1', 'port' => 6379]],
+            $resolver->resolveSlaves('mymaster')
+        );
+    }
+
+    #[Test]
+    public function itThrowsWhenMasterNotFound(): void
+    {
+        $client = $this->makeClient();
+        $client->method('master')->willReturn(false);
+
+        $resolver = $this->makeResolver($client);
+
+        $this->expectException(SentinelException::class);
+        $this->expectExceptionMessage('master group [mymaster] not found');
+
+        $resolver->resolveMaster('mymaster');
+    }
+
+    #[Test]
+    public function itThrowsWhenMasterFlaggedDown(): void
+    {
+        $client = $this->makeClient();
+        $client->method('master')->willReturn([
+            'ip' => '10.0.0.1',
+            'port' => 6379,
+            'flags' => 'master,s_down,o_down',
+            'role-reported' => 'master',
+        ]);
+
+        $resolver = $this->makeResolver($client);
+
+        $this->expectException(SentinelException::class);
+        $this->expectExceptionMessage('reported down');
+
+        $resolver->resolveMaster('mymaster');
+    }
+
+    #[Test]
+    public function itThrowsWhenMasterIsDisconnected(): void
+    {
+        $client = $this->makeClient();
+        $client->method('master')->willReturn([
+            'ip' => '10.0.0.1',
+            'port' => 6379,
+            'flags' => 'master,disconnected',
+            'role-reported' => 'master',
+        ]);
+
+        $resolver = $this->makeResolver($client);
+
+        $this->expectException(SentinelException::class);
+        $this->expectExceptionMessage('reported down');
+
+        $resolver->resolveMaster('mymaster');
+    }
+
+    #[Test]
+    public function itDoesNotMistakeUnrelatedDownSubstringFlagsAsMasterDown(): void
+    {
+        // 假想未來 Sentinel 加入 'shutdown_pending' / 'xxx_countdown' 等含 down 子字串但非 master down 的 flag；
+        // token-based 比對應該不誤判為 down。
+        $client = $this->makeClient();
+        $client->method('master')->willReturn([
+            'ip' => '10.0.0.1',
+            'port' => 6379,
+            'flags' => 'master,shutdown_pending,countdown_42',
+            'role-reported' => 'master',
+        ]);
+
+        $resolver = $this->makeResolver($client);
+
+        $this->assertSame(
+            ['host' => '10.0.0.1', 'port' => 6379],
+            $resolver->resolveMaster('mymaster')
+        );
+    }
+
+    #[Test]
+    public function itFiltersOutSlavesWithMasterLinkDown(): void
+    {
+        // master_link_down 表示 slave 與 master 連線斷、資料可能落後，不該被當作可讀節點。
+        $client = $this->makeClient();
+        $client->method('slaves')->willReturn([
+            ['ip' => '10.0.0.2', 'port' => 6379, 'flags' => 'slave'],
+            ['ip' => '10.0.0.3', 'port' => 6379, 'flags' => 'slave,master_link_down'],
+        ]);
+
+        $resolver = $this->makeResolver($client);
+
+        $this->assertSame(
+            [['host' => '10.0.0.2', 'port' => 6379]],
+            $resolver->resolveSlaves('mymaster')
+        );
+    }
+
+    #[Test]
+    public function itThrowsWhenMasterRoleIsNotMaster(): void
+    {
+        $client = $this->makeClient();
+        $client->method('master')->willReturn([
+            'ip' => '10.0.0.1',
+            'port' => 6379,
+            'flags' => 'master',
+            'role-reported' => 'slave',
+        ]);
+
+        $resolver = $this->makeResolver($client);
+
+        $this->expectException(SentinelException::class);
+        $this->expectExceptionMessage("role must be 'master'");
+
+        $resolver->resolveMaster('mymaster');
+    }
+
+    #[Test]
+    public function itInvalidatesMasterCacheForSpecificService(): void
+    {
+        $client = $this->makeClient();
+        $client->expects($this->exactly(2))
+            ->method('master')
+            ->willReturn([
+                'ip' => '10.0.0.1',
+                'port' => 6379,
+                'flags' => 'master',
+                'role-reported' => 'master',
+            ]);
+
+        $resolver = $this->makeResolver($client);
+        $resolver->resolveMaster('mymaster');
+        $resolver->invalidate('mymaster');
+        $resolver->resolveMaster('mymaster');
+    }
+
+    #[Test]
+    public function itInvalidatesAllCaches(): void
+    {
+        $client = $this->makeClient();
+        $client->expects($this->exactly(2))
+            ->method('master')
+            ->willReturn([
+                'ip' => '10.0.0.1',
+                'port' => 6379,
+                'flags' => 'master',
+                'role-reported' => 'master',
+            ]);
+
+        $resolver = $this->makeResolver($client);
+        $resolver->resolveMaster('mymaster');
+        $resolver->invalidate();
+        $resolver->resolveMaster('mymaster');
+    }
+
+    #[Test]
+    public function itCachesSlavesResolution(): void
+    {
+        $client = $this->makeClient();
+        $client->expects($this->once())
+            ->method('slaves')
+            ->willReturn([
+                ['ip' => '10.0.0.2', 'port' => 6379, 'flags' => 'slave'],
+            ]);
+
+        $resolver = $this->makeResolver($client);
+        $resolver->resolveSlaves('mymaster');
+        $resolver->resolveSlaves('mymaster');
+    }
+
+    #[Test]
+    public function itInvalidatesSlavesCacheForSpecificService(): void
+    {
+        $client = $this->makeClient();
+        $client->expects($this->exactly(2))
+            ->method('slaves')
+            ->willReturn([
+                ['ip' => '10.0.0.2', 'port' => 6379, 'flags' => 'slave'],
+            ]);
+
+        $resolver = $this->makeResolver($client);
+        $resolver->resolveSlaves('mymaster');
+        $resolver->invalidate('mymaster');
+        $resolver->resolveSlaves('mymaster');
+    }
+
+    #[Test]
+    public function itKeepsOtherServiceCacheWhenInvalidatingOne(): void
+    {
+        $masterInfo = [
+            'mymaster' => [
+                'ip' => '10.0.0.1',
+                'port' => 6379,
+                'flags' => 'master',
+                'role-reported' => 'master',
+            ],
+            'replica' => [
+                'ip' => '10.0.0.5',
+                'port' => 6379,
+                'flags' => 'master',
+                'role-reported' => 'master',
+            ],
+        ];
+
+        $observed = [];
+        $client = $this->makeClient();
+        $client->method('master')->willReturnCallback(function (string $service) use ($masterInfo, &$observed) {
+            $observed[] = $service;
+            return $masterInfo[$service];
+        });
+
+        $resolver = $this->makeResolver($client);
+        $resolver->resolveMaster('mymaster');
+        $resolver->resolveMaster('replica');
+        $resolver->invalidate('mymaster');
+        $resolver->resolveMaster('mymaster');  // 重新取
+        $resolver->resolveMaster('replica');  // 快取仍有效
+
+        $this->assertSame(['mymaster', 'replica', 'mymaster'], $observed);
+    }
+
+    #[Test]
+    public function itLazilyCreatesSentinelClient(): void
+    {
+        $client = $this->makeClient();
+        $client->method('master')->willReturn([
+            'ip' => '10.0.0.1',
+            'port' => 6379,
+            'flags' => 'master',
+            'role-reported' => 'master',
+        ]);
+
+        $builderCalls = 0;
+        $resolver = $this->makeResolver($client, $builderCalls);
+
+        $this->assertSame(0, $builderCalls);
+        $resolver->resolveMaster('mymaster');
+        $this->assertSame(1, $builderCalls);
+        $resolver->resolveMaster('mymaster');
+        $this->assertSame(1, $builderCalls);
+    }
+
+    #[Test]
+    public function itRecreatesSentinelClientAfterFullInvalidateWhenCacheWasUsed(): void
+    {
+        $client = $this->makeClient();
+        $client->method('master')->willReturn([
+            'ip' => '10.0.0.1',
+            'port' => 6379,
+            'flags' => 'master',
+            'role-reported' => 'master',
+        ]);
+
+        $builderCalls = 0;
+        $resolver = $this->makeResolver($client, $builderCalls);
+        $resolver->resolveMaster('mymaster');
+
+        $this->assertSame(1, $builderCalls);
+
+        $resolver->invalidate();
+        $resolver->resolveMaster('mymaster');
+
+        // 不帶參數的 invalidate 同時丟棄底層 sentinel client，讓下一次呼叫重新建立連線；
+        // 用於 Sentinel 入口發生短暫失聯時的 hard reset 情境。
+        $this->assertSame(2, $builderCalls);
+    }
+
+    #[Test]
+    public function itAllowsRetryWhenClientBuilderThrowsInitially(): void
+    {
+        // 「啟動時 Sentinel 暫時不通、稍後恢復」情境：第一次 builder 拋例外、Resolver 不應 cache 失敗狀態，
+        // 下次呼叫該重新嘗試 builder。
+        $attempts = 0;
+        $client = $this->makeClient();
+        $client->method('master')->willReturn([
+            'ip' => '10.0.0.1',
+            'port' => 6379,
+            'flags' => 'master',
+            'role-reported' => 'master',
+        ]);
+
+        $resolver = new Resolver(function () use (&$attempts, $client): SentinelClientInterface {
+            $attempts++;
+            if ($attempts === 1) {
+                throw new SentinelException('first attempt fail', SentinelException::CONNECTION_ERROR);
+            }
+            return $client;
+        });
+
+        try {
+            $resolver->resolveMaster('mymaster');
+            $this->fail('first call should throw');
+        } catch (SentinelException $e) {
+            $this->assertSame('first attempt fail', $e->getMessage());
+        }
+
+        $this->assertSame(
+            ['host' => '10.0.0.1', 'port' => 6379],
+            $resolver->resolveMaster('mymaster')
+        );
+        $this->assertSame(2, $attempts);
+    }
+}

--- a/tests/Unit/Sentinel/SentinelConnectorTest.php
+++ b/tests/Unit/Sentinel/SentinelConnectorTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Sentinel;
+
+use InvalidArgumentException;
+use Lab104\Laravel\Redis\Sentinel\ResolverInterface;
+use Lab104\Laravel\Redis\Sentinel\SentinelConnector;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class SentinelConnectorTest extends TestCase
+{
+    #[Test]
+    public function masterResolverClosureDoesNotInvalidateOnFirstCall(): void
+    {
+        $resolver = $this->createMock(ResolverInterface::class);
+        $resolver->expects($this->never())->method('invalidate');
+        $resolver->expects($this->once())
+            ->method('resolveMaster')
+            ->with('mymaster')
+            ->willReturn(['host' => '10.0.0.1', 'port' => 6379]);
+
+        $closure = SentinelConnector::makeMasterResolverClosure($resolver, 'mymaster');
+        $this->assertSame(['host' => '10.0.0.1', 'port' => 6379], $closure());
+    }
+
+    #[Test]
+    public function masterResolverClosureInvalidatesOnSubsequentCalls(): void
+    {
+        $resolver = $this->createMock(ResolverInterface::class);
+        $resolver->expects($this->exactly(2))
+            ->method('invalidate')
+            ->with('mymaster');
+        $resolver->expects($this->exactly(3))
+            ->method('resolveMaster')
+            ->with('mymaster')
+            ->willReturn(['host' => '10.0.0.1', 'port' => 6379]);
+
+        $closure = SentinelConnector::makeMasterResolverClosure($resolver, 'mymaster');
+        $closure();  // 第一次：不 invalidate
+        $closure();  // 第二次：invalidate
+        $closure();  // 第三次：invalidate
+    }
+
+    #[Test]
+    public function eachClosureTracksAttemptsIndependently(): void
+    {
+        $resolver = $this->createMock(ResolverInterface::class);
+        $resolver->method('resolveMaster')->willReturn(['host' => '10.0.0.1', 'port' => 6379]);
+
+        // 每個 closure 各自管自己的 attempts 計數，不會互相污染：即使共用同一個 resolver，
+        // 不同 service 的 closure 第一次呼叫都不該觸發 invalidate。
+        $resolver->expects($this->never())->method('invalidate');
+
+        $closureA = SentinelConnector::makeMasterResolverClosure($resolver, 'mymaster');
+        $closureB = SentinelConnector::makeMasterResolverClosure($resolver, 'replica');
+        $closureA();
+        $closureB();
+    }
+
+    #[Test]
+    public function connectRejectsMissingService(): void
+    {
+        $connector = new SentinelConnector();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("'service'");
+
+        $connector->connect(
+            ['sentinels' => [['host' => '10.0.0.1', 'port' => 26379]]],
+            []
+        );
+    }
+
+    #[Test]
+    public function connectRejectsMissingSentinels(): void
+    {
+        $connector = new SentinelConnector();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("'sentinels'");
+
+        $connector->connect(['service' => 'mymaster'], []);
+    }
+
+    #[Test]
+    public function connectRejectsEmptySentinels(): void
+    {
+        $connector = new SentinelConnector();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Sentinel host list must not be empty');
+
+        $connector->connect(['service' => 'mymaster', 'sentinels' => []], []);
+    }
+
+    #[Test]
+    public function connectReportsBadSentinelEntryWithIndex(): void
+    {
+        $connector = new SentinelConnector();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('sentinels[1]');
+
+        $connector->connect(
+            [
+                'service' => 'mymaster',
+                'sentinels' => [
+                    ['host' => 'sentinel-a', 'port' => 26379],
+                    ['port' => 26379],  // 缺 host
+                ],
+            ],
+            []
+        );
+    }
+}


### PR DESCRIPTION
## 變更摘要

新增 `Lab104\Laravel\Redis\Sentinel` namespace，提供以 phpredis `\RedisSentinel` 為底的 Laravel Redis driver `phpredis-sentinel`。應用端設定 `'driver' => 'phpredis-sentinel'` 後即可透過 Sentinel 集群（單一 LB endpoint 或多個 sentinel host）解析當前 master 並建立連線；連線失敗時 connector closure 自動重 query Sentinel 取得新 master，達成對呼叫端透明的 failover。

既有 `KeysByScan` 與 predis 使用者完全不受影響（`ext-redis` 仍在 `suggest`、不在 `require`）。

### 新增

- `src/Sentinel/ResolverInterface.php`
  - 對外契約：`resolveMaster()` / `resolveSlaves()` / `invalidate()`
- `src/Sentinel/Resolver.php`
  - master / slaves 解析、in-memory cache、`slave=0` 邊界 fallback、token-based down flag 比對
  - `MASTER_DOWN_FLAGS = [s_down, o_down, disconnected]`、`SLAVE_DOWN_FLAGS` 額外含 `master_link_down`
  - `invalidate(null)` 同時丟棄底層 `\RedisSentinel` client（hard reset）
- `src/Sentinel/SentinelClientInterface.php`
  - Sentinel 端唯讀查詢介面（`master()` / `slaves()`），讓 Resolver 純單元測試可 mock
- `src/Sentinel/PhpRedisSentinelClient.php`
  - phpredis `\RedisSentinel` 實作；按 sentinels 清單順序輪試直到任一可連
  - 公開 `assertSentinelsShape()` helper，與 SentinelConnector 共用 sentinels 結構驗證
- `src/Sentinel/SentinelConnector.php`
  - 繼承 `Illuminate\Redis\Connectors\PhpRedisConnector`，先解析 master 再委派建立 `\Redis`
  - `makeMasterResolverClosure()` 在 reconnect 第二次起 invalidate Resolver，自動重 query Sentinel
  - 拆 `sentinel_connect_timeout` / `sentinel_read_timeout` 為獨立 key，`sentinel_timeout` 為共用 fallback
- `src/Sentinel/SentinelException.php`
  - Sentinel 領域例外（`RESOLVE_ERROR` / `CONNECTION_ERROR`），`previous` chain 保留底層 throwable
- `src/Sentinel/SentinelServiceProvider.php`
  - composer auto-discover 自動註冊 `phpredis-sentinel` driver 到 `RedisManager`
- `tests/Unit/Sentinel/ResolverTest.php` — 21 項測試
- `tests/Unit/Sentinel/SentinelConnectorTest.php` — 7 項測試
- `tests/Unit/Sentinel/PhpRedisSentinelClientTest.php` — 6 項測試
- `doc/sentinel.md`
  - 完整機制文件（10 章）：架構（Mermaid flowchart）、元件職責、解析流程、cache 失效策略、reconnect 時序（Mermaid sequenceDiagram）、`slave=0` 邊界、測試覆蓋、設定 / `.env` 對應、故障排除、套件版本相容

### 異動

- `README.md`
  - 新增 Sentinel 章節：設定範例、欄位說明、connection cache 失效策略、`slave=0` 邊界處理、進階讀流量分流範例、failover 預期行為
- `composer.json`
  - `suggest` 宣告 `ext-redis >= 6.0`（僅 Sentinel namespace 需要；KeysByScan 不需要）
  - `extra.laravel.providers` 新增 `SentinelServiceProvider` 入口
- `.gitignore`
  - 補 `.tmp/`

## 測試結果

- [x] Lint 通過（phpcs PSR-12）
- [x] Unit Test 通過（Sentinel 34/34，66 assertions；KeysByScan 既有測試需實機 Redis 由 CI 跑）

```bash
vendor/bin/phpunit tests/Unit/Sentinel/
# Tests: 34, Assertions: 66
```

整合測試（連實機 Sentinel + 手動觸發 failover 驗證 reconnect）由應用端負責；本套件不維護整合測試以避免綁定特定 Sentinel 部署。

### 測試覆蓋面

#### 正常情境

- [x] 當 Laravel 啟動且套件被 composer auto-discover 時，`SentinelServiceProvider` 自動註冊 `phpredis-sentinel` driver
- [x] 當應用升級至含 Sentinel namespace 的版本後，既有 `KeysByScan` 行為不受影響（namespace 並存、`src/KeysByScan.php` 完全未動）

#### 邊界情境

- [x] 當 Sentinel 回報 slave list 為 0（或全為 down）時，`Resolver::fetchSlaves()` 將 master 加入 slave 清單作為 fallback（避免讀流量無處可去）
- [x] 當同一 process 內多次取得連線時，`Resolver` in-memory cache 不重複向 Sentinel 查詢
- [x] 當 cache 中的 master 連線失敗時，`SentinelConnector::makeMasterResolverClosure()` 在 reconnect 第二次起 invalidate cache 並重 query Sentinel 取得新 master
- [x] 當 flags 含 `*_countdown` / `shutdown_pending` 等子字串包含 `down` 但語意非 master down 的 token 時，token-based 比對不誤判

#### 錯誤情境

- [x] 當所有 sentinels 都連不到時，`PhpRedisSentinelClient::client()` 在輪試完成後拋 `SentinelException`（`CONNECTION_ERROR`），訊息含最後一次 underlying error，`previous` 保留 chain（不 hang）
- [x] 當 Sentinel 回報 master `flags` 含 `s_down` / `o_down` / `disconnected` 時，`Resolver::fetchMaster()` 拋 `SentinelException::masterDown()`
- [x] 當 Sentinel 回報的 master 角色不符時，`Resolver::fetchMaster()` 拋 `SentinelException::masterRoleMismatch()`
- [x] 當 `sentinels` 設定結構不符（缺 host 等）時，`PhpRedisSentinelClient::assertSentinelsShape()` 拋 `InvalidArgumentException`，訊息含 `sentinels[N]` index

## 風險評估

本套件為共用 lib（無上線部署動作），merge 後對既有使用方影響：

- **既有 `KeysByScan` 使用方**：無影響。`Lab104\Laravel\Redis\Sentinel` 是新增子 namespace，`src/KeysByScan.php` 完全未動，PSR-4 並存無衝突。應用端不主動切到 `phpredis-sentinel` driver 也不會走進 Sentinel 程式路徑（`SentinelServiceProvider::boot()` 用 `afterResolving('redis')` 只在 redis manager 解析後才註冊 driver；driver 沒被選用就不會 instantiate）。
- **新採用 Sentinel driver 的使用方**：建議搭配實機 failover 演練、long-running worker（如 Octane / Swoole）的 connection 生命週期驗證。詳見 [`doc/sentinel.md`](doc/sentinel.md) 第 5.4 節。
